### PR TITLE
Fix project GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/notifiable-sender.
+Bug reports and pull requests are welcome on GitHub at https://github.com/FutureWorkshops/notifiable-sender.
 
 
 ## License


### PR DESCRIPTION
The url `https://github.com/[USERNAME]/notifiable-sender` redirects to a 404 page. So, replacing the `[USERNAME]` placeholder to the right GitHub user fix the link.